### PR TITLE
weatherclient should use latlng

### DIFF
--- a/pkg/http/controllers.go
+++ b/pkg/http/controllers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dsauerbrun/cragcast/pkg/weather-client"
+	client "github.com/dsauerbrun/cragcast/pkg/weather-client"
 )
 
 const (
@@ -17,7 +17,7 @@ type Controllers struct {
 }
 
 func (c *Controllers) GetForecast(w http.ResponseWriter, r *http.Request) {
-	forcast, err := c.cl.GetForecast(52, 75)
+	forcast, err := c.cl.GetForecast(40.0294122, -105.3223779)
 	if err != nil {
 		// TODO(joshrosso): need to be more thoughtful with the error
 		// message we pass back in the body

--- a/pkg/weather-client/client.go
+++ b/pkg/weather-client/client.go
@@ -28,7 +28,7 @@ func New() WeatherClient {
 	return newNoaaClient()
 }
 
-func (nc *NoaaClient) GetForecast(lat float64, lng float64) (*ForecastResponse, error) {
+func (nc *NoaaClient) GetForecast(lat, lng float64) (*ForecastResponse, error) {
 	// 40.0294122,-105.3223779 is lat,lng for boulder
 	xCoord, yCoord, stationCode, err := nc.getNoaaPointInfo(lat, lng)
 	if err != nil {
@@ -62,7 +62,7 @@ func newNoaaClient() *NoaaClient {
 	}
 }
 
-func (nc *NoaaClient) getNoaaPointInfo(lat float64, lng float64) (xCoord float64, yCoord float64, stationCode string, err error) {
+func (nc *NoaaClient) getNoaaPointInfo(lat, lng float64) (xCoord float64, yCoord float64, stationCode string, err error) {
 	// cache this in the future as it will basically never change
 	pointUrl := fmt.Sprintf("%s/points/%f,%f", nc.APIEndpoint, lat, lng)
 	response, err := http.Get(pointUrl)

--- a/pkg/weather-client/client.go
+++ b/pkg/weather-client/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 )
 
 const (
@@ -13,62 +12,8 @@ const (
 	weatherDotGovAPIEndpoint = "https://api.weather.gov"
 )
 
-type Elevation struct {
-	UnitCode string  `json:"unitCode"`
-	Value    float64 `json:"value"`
-}
-
-type Dewpoint struct {
-	UnitCode string  `json:"unitCode"`
-	Value    float64 `json:"value"`
-}
-
-type ProbabilityOfPrecipitation struct {
-	UnitCode string `json:"unitCode"`
-	Value    int    `json:"value"`
-}
-
-type RelativeHumidity struct {
-	UnitCode string `json:"unitCode"`
-	Value    int    `json:"value"`
-}
-
-type Period struct {
-	Dewpoint                   Dewpoint                   `json:"dewpoint"`
-	EndTime                    time.Time                  `json:"endTime"`
-	Icon                       string                     `json:"icon"`
-	IsDaytime                  bool                       `json:"isDaytime"`
-	Name                       string                     `json:"name"`
-	Number                     int                        `json:"number"`
-	ProbabilityOfPrecipitation ProbabilityOfPrecipitation `json:"probabilityOfPrecipitation"`
-	RelativeHumidity           RelativeHumidity           `json:"relativeHumidity"`
-	ShortForecast              string                     `json:"shortForecast"`
-	StartTime                  time.Time                  `json:"startTime"`
-	Temperature                int                        `json:"temperature"`
-	TemperatureTrend           interface{}                `json:"temperatureTrend"`
-	TemperatureUnit            string                     `json:"temperatureUnit"`
-	WindDirection              string                     `json:"windDirection"`
-	WindSpeed                  string                     `json:"windSpeed"`
-}
-
-type Properties struct {
-	Elevation         Elevation `json:"elevation"`
-	ForecastGenerator string    `json:"forecastGenerator"`
-	GeneratedAt       time.Time `json:"generatedAt"`
-	Periods           []Period  `json:"periods"`
-	Units             string    `json:"units"`
-	UpdateTime        time.Time `json:"updateTime"`
-	Updated           time.Time `json:"updated"`
-	ValidTimes        string    `json:"validTimes"`
-}
-
-type ForecastResponse struct {
-	Properties Properties `json:"properties"`
-	Type       string     `json:"type"`
-}
-
 type WeatherClient interface {
-	GetForecast(xCoordinate, yCoordinate float32) (*ForecastResponse, error)
+	GetForecast(lat float64, lng float64) (*ForecastResponse, error)
 }
 
 type NoaaClient struct {
@@ -83,10 +28,37 @@ func New() WeatherClient {
 	return newNoaaClient()
 }
 
-func (nc *NoaaClient) GetForecast(xCoordinate float32, yCoordinate float32) (*ForecastResponse, error) {
-	// BOU weather office(boulder), 52X, 75Y this is boulder
-	url := fmt.Sprintf("%s/gridpoints/BOU/%f,%f/forecast/hourly",
-		nc.APIEndpoint, xCoordinate, yCoordinate)
+func (nc *NoaaClient) getNoaaPointInfo(lat float64, lng float64) (xCoord float64, yCoord float64, stationCode string, err error) {
+	// cache this in the future as it will basically never change
+	pointUrl := fmt.Sprintf("%s/points/%f,%f", nc.APIEndpoint, lat, lng)
+	response, err := http.Get(pointUrl)
+	if err != nil {
+		return 0, 0, "", err
+	}
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	pointData := &PointResponse{}
+	err = json.Unmarshal(responseBody, pointData)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	return float64(pointData.Properties.GridX), float64(pointData.Properties.GridY), pointData.Properties.Cwa, nil
+}
+
+func (nc *NoaaClient) GetForecast(lat float64, lng float64) (*ForecastResponse, error) {
+	// 40.0294122,-105.3223779 is lat,lng for boulder
+	xCoord, yCoord, stationCode, err := nc.getNoaaPointInfo(lat, lng)
+	if err != nil {
+		return nil, err
+	}
+
+	// BOU weather office(boulder), 52X, 75Y is boulder
+	url := fmt.Sprintf("%s/gridpoints/%s/%f,%f/forecast/hourly",
+		nc.APIEndpoint, stationCode, xCoord, yCoord)
 	response, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/pkg/weather-client/client.go
+++ b/pkg/weather-client/client.go
@@ -28,27 +28,6 @@ func New() WeatherClient {
 	return newNoaaClient()
 }
 
-func (nc *NoaaClient) getNoaaPointInfo(lat float64, lng float64) (xCoord float64, yCoord float64, stationCode string, err error) {
-	// cache this in the future as it will basically never change
-	pointUrl := fmt.Sprintf("%s/points/%f,%f", nc.APIEndpoint, lat, lng)
-	response, err := http.Get(pointUrl)
-	if err != nil {
-		return 0, 0, "", err
-	}
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return 0, 0, "", err
-	}
-
-	pointData := &PointResponse{}
-	err = json.Unmarshal(responseBody, pointData)
-	if err != nil {
-		return 0, 0, "", err
-	}
-
-	return float64(pointData.Properties.GridX), float64(pointData.Properties.GridY), pointData.Properties.Cwa, nil
-}
-
 func (nc *NoaaClient) GetForecast(lat float64, lng float64) (*ForecastResponse, error) {
 	// 40.0294122,-105.3223779 is lat,lng for boulder
 	xCoord, yCoord, stationCode, err := nc.getNoaaPointInfo(lat, lng)
@@ -81,4 +60,25 @@ func newNoaaClient() *NoaaClient {
 	return &NoaaClient{
 		APIEndpoint: weatherDotGovAPIEndpoint,
 	}
+}
+
+func (nc *NoaaClient) getNoaaPointInfo(lat float64, lng float64) (xCoord float64, yCoord float64, stationCode string, err error) {
+	// cache this in the future as it will basically never change
+	pointUrl := fmt.Sprintf("%s/points/%f,%f", nc.APIEndpoint, lat, lng)
+	response, err := http.Get(pointUrl)
+	if err != nil {
+		return 0, 0, "", err
+	}
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	pointData := &PointResponse{}
+	err = json.Unmarshal(responseBody, pointData)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	return float64(pointData.Properties.GridX), float64(pointData.Properties.GridY), pointData.Properties.Cwa, nil
 }

--- a/pkg/weather-client/client.go
+++ b/pkg/weather-client/client.go
@@ -13,7 +13,7 @@ const (
 )
 
 type WeatherClient interface {
-	GetForecast(lat float64, lng float64) (*ForecastResponse, error)
+	GetForecast(lat, lng float64) (*ForecastResponse, error)
 }
 
 type NoaaClient struct {

--- a/pkg/weather-client/types.go
+++ b/pkg/weather-client/types.go
@@ -58,11 +58,7 @@ type ForecastResponse struct {
 
 type PointResponse struct {
 	Properties struct {
-		_ID                 string `json:"@id"`
-		_Type               string `json:"@type"`
-		County              string `json:"county"`
 		Cwa                 string `json:"cwa"`
-		FireWeatherZone     string `json:"fireWeatherZone"`
 		Forecast            string `json:"forecast"`
 		ForecastGridData    string `json:"forecastGridData"`
 		ForecastHourly      string `json:"forecastHourly"`
@@ -73,26 +69,7 @@ type PointResponse struct {
 		GridY               int    `json:"gridY"`
 		ObservationStations string `json:"observationStations"`
 		RadarStation        string `json:"radarStation"`
-		RelativeLocation    struct {
-			Geometry struct {
-				Coordinates []float64 `json:"coordinates"`
-				Type        string    `json:"type"`
-			} `json:"geometry"`
-			Properties struct {
-				Bearing struct {
-					UnitCode string `json:"unitCode"`
-					Value    int    `json:"value"`
-				} `json:"bearing"`
-				City     string `json:"city"`
-				Distance struct {
-					UnitCode string  `json:"unitCode"`
-					Value    float64 `json:"value"`
-				} `json:"distance"`
-				State string `json:"state"`
-			} `json:"properties"`
-			Type string `json:"type"`
-		} `json:"relativeLocation"`
-		TimeZone string `json:"timeZone"`
+		TimeZone            string `json:"timeZone"`
 	} `json:"properties"`
 	Type string `json:"type"`
 }

--- a/pkg/weather-client/types.go
+++ b/pkg/weather-client/types.go
@@ -1,0 +1,98 @@
+package client
+
+import "time"
+
+type Elevation struct {
+	UnitCode string  `json:"unitCode"`
+	Value    float64 `json:"value"`
+}
+
+type Dewpoint struct {
+	UnitCode string  `json:"unitCode"`
+	Value    float64 `json:"value"`
+}
+
+type ProbabilityOfPrecipitation struct {
+	UnitCode string `json:"unitCode"`
+	Value    int    `json:"value"`
+}
+
+type RelativeHumidity struct {
+	UnitCode string `json:"unitCode"`
+	Value    int    `json:"value"`
+}
+
+type Period struct {
+	Dewpoint                   Dewpoint                   `json:"dewpoint"`
+	EndTime                    time.Time                  `json:"endTime"`
+	Icon                       string                     `json:"icon"`
+	IsDaytime                  bool                       `json:"isDaytime"`
+	Name                       string                     `json:"name"`
+	Number                     int                        `json:"number"`
+	ProbabilityOfPrecipitation ProbabilityOfPrecipitation `json:"probabilityOfPrecipitation"`
+	RelativeHumidity           RelativeHumidity           `json:"relativeHumidity"`
+	ShortForecast              string                     `json:"shortForecast"`
+	StartTime                  time.Time                  `json:"startTime"`
+	Temperature                int                        `json:"temperature"`
+	TemperatureTrend           interface{}                `json:"temperatureTrend"`
+	TemperatureUnit            string                     `json:"temperatureUnit"`
+	WindDirection              string                     `json:"windDirection"`
+	WindSpeed                  string                     `json:"windSpeed"`
+}
+
+type Properties struct {
+	Elevation         Elevation `json:"elevation"`
+	ForecastGenerator string    `json:"forecastGenerator"`
+	GeneratedAt       time.Time `json:"generatedAt"`
+	Periods           []Period  `json:"periods"`
+	Units             string    `json:"units"`
+	UpdateTime        time.Time `json:"updateTime"`
+	Updated           time.Time `json:"updated"`
+	ValidTimes        string    `json:"validTimes"`
+}
+
+type ForecastResponse struct {
+	Properties Properties `json:"properties"`
+	Type       string     `json:"type"`
+}
+
+type PointResponse struct {
+	Properties struct {
+		_ID                 string `json:"@id"`
+		_Type               string `json:"@type"`
+		County              string `json:"county"`
+		Cwa                 string `json:"cwa"`
+		FireWeatherZone     string `json:"fireWeatherZone"`
+		Forecast            string `json:"forecast"`
+		ForecastGridData    string `json:"forecastGridData"`
+		ForecastHourly      string `json:"forecastHourly"`
+		ForecastOffice      string `json:"forecastOffice"`
+		ForecastZone        string `json:"forecastZone"`
+		GridID              string `json:"gridId"`
+		GridX               int    `json:"gridX"`
+		GridY               int    `json:"gridY"`
+		ObservationStations string `json:"observationStations"`
+		RadarStation        string `json:"radarStation"`
+		RelativeLocation    struct {
+			Geometry struct {
+				Coordinates []float64 `json:"coordinates"`
+				Type        string    `json:"type"`
+			} `json:"geometry"`
+			Properties struct {
+				Bearing struct {
+					UnitCode string `json:"unitCode"`
+					Value    int    `json:"value"`
+				} `json:"bearing"`
+				City     string `json:"city"`
+				Distance struct {
+					UnitCode string  `json:"unitCode"`
+					Value    float64 `json:"value"`
+				} `json:"distance"`
+				State string `json:"state"`
+			} `json:"properties"`
+			Type string `json:"type"`
+		} `json:"relativeLocation"`
+		TimeZone string `json:"timeZone"`
+	} `json:"properties"`
+	Type string `json:"type"`
+}


### PR DESCRIPTION
weatherclient interface uses latlng now. stationcode, xcoord/ycoord are fetched via noaa's points endpoint.

I also moved the response structs into their own file to keep client.go a bit cleaner